### PR TITLE
fix: 대화 시작 시 흐름 수정 및 대화 턴 저장 방식 수정

### DIFF
--- a/backend/app/services/dialogue_workflow.py
+++ b/backend/app/services/dialogue_workflow.py
@@ -177,7 +177,7 @@ class DialogueWorkflow:
             
             # 해당 세션의 기존 대화 내역 조회
             conversations_response = client.table("conversations").select(
-                "id, question_text, user_response_text, conversation_order"
+                "id, ai_output, user_input, conversation_order"
             ).eq("session_id", session_id).order("conversation_order").execute()
             
             print(f"💬 기존 대화 내역: {len(conversations_response.data) if conversations_response.data else 0}개")
@@ -192,15 +192,15 @@ class DialogueWorkflow:
             # 기존 대화 내용 추가
             if conversations_response.data:
                 for conv in conversations_response.data:
-                    if conv.get("question_text"):
+                    if conv.get("ai_output"):
                         message_history.append({
                             "role": "assistant", 
-                            "content": conv["question_text"]
+                            "content": conv["ai_output"]
                         })
-                    if conv.get("user_response_text"):
+                    if conv.get("user_input"):
                         message_history.append({
                             "role": "user", 
-                            "content": conv["user_response_text"]
+                            "content": conv["user_input"]
                         })
             
             state["message_history"] = message_history
@@ -457,9 +457,9 @@ class DialogueWorkflow:
                 "user_id": user_id,
                 "photo_id": photo_context.get("photo_id"),
                 "conversation_order": next_order,
-                "question_text": ai_response,
+                "ai_output": ai_response,
                 "question_type": "open_ended",  # 기본값
-                "user_response_text": user_message,
+                "user_input": user_message,
                 "is_cist_item": False
             }
             

--- a/frontend/lib/screens/conversation_screen.dart
+++ b/frontend/lib/screens/conversation_screen.dart
@@ -69,6 +69,9 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
   bool _isApiCallInProgress = false;
   Timer? _apiTimeoutTimer;
 
+  // 자동 스크롤을 위한 ScrollController 추가
+  final ScrollController _scrollController = ScrollController();
+
   @override
   void initState() {
     super.initState();
@@ -87,6 +90,7 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
 
   @override
   void dispose() {
+    _scrollController.dispose();
     _audioService.dispose();
     super.dispose();
   }
@@ -103,6 +107,9 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
       setState(() {
         apiResult = conversation.question;
       });
+
+      // 새로운 AI 응답이 들어올 때 자동 스크롤
+      _scrollToBottom();
 
       // === 초기 질문/음성파일만 재생 ===
       if (conversation.audioUrl != null && conversation.audioUrl.isNotEmpty) {
@@ -323,6 +330,9 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
           print('[디버그] _recognizedText 업데이트: $_recognizedText');
         });
         
+        // 새로운 사용자 입력이 들어올 때 자동 스크롤
+        _scrollToBottom();
+        
         // AI 응답 음성 재생 (있는 경우에만)
         if (data['audio_url'] != null && data['audio_url'].isNotEmpty) {
           await _audioService.loadAudio(data['audio_url']);
@@ -352,6 +362,9 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
                 apiResult = conversation.question;
               });
               
+              // AI의 새로운 질문이 들어올 때 자동 스크롤
+              _scrollToBottom();
+              
               // AI의 새로운 질문 음성 재생
               if (conversation.audioUrl != null && conversation.audioUrl.isNotEmpty) {
                 await _audioService.loadAudio(conversation.audioUrl);
@@ -377,6 +390,9 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
             setState(() {
               apiResult = conversation.question;
             });
+            
+            // AI의 새로운 질문이 들어올 때 자동 스크롤
+            _scrollToBottom();
             
             if (conversation.audioUrl != null && conversation.audioUrl.isNotEmpty) {
               await _audioService.loadAudio(conversation.audioUrl);
@@ -460,6 +476,7 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
       ),
 
       body: SingleChildScrollView(
+        controller: _scrollController,
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20),
           child: Column(
@@ -577,6 +594,19 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
   void toggleSTT() {
     setState(() {
       isSTTActive = !isSTTActive;
+    });
+  }
+
+  /// 자동 스크롤 함수
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients && mounted) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
     });
   }
 

--- a/frontend/lib/screens/conversation_screen_simple.dart
+++ b/frontend/lib/screens/conversation_screen_simple.dart
@@ -36,6 +36,7 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
   bool _isProcessing = false;
   String _processingMessage = '';
   Photo? _currentPhoto;
+  final ScrollController _scrollController = ScrollController();
 
   @override
   void initState() {
@@ -47,6 +48,7 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
   void dispose() {
     _webSocketService.disconnect();
     _messageController.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -167,6 +169,9 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
         });
         
         print('✅ AI 메시지 UI에 추가됨: ${_messages.length}개 메시지');
+        
+        // AI 응답이 들어올 때 자동 스크롤
+        _scrollToBottom();
       } else {
         print('⚠️ 예상과 다른 메시지 형식:');
         print('  type: ${message['type']}');
@@ -236,6 +241,9 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
     });
 
     print('💬 UI에 사용자 메시지 추가됨: ${_messages.length}개 메시지');
+    
+    // 사용자 메시지가 들어올 때 자동 스크롤
+    _scrollToBottom();
 
     // WebSocket으로 전송
     final photoContext = {
@@ -307,6 +315,19 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
     if (mounted) {
       Navigator.of(context).pop();
     }
+  }
+  
+  /// 자동 스크롤 함수
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients && mounted) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
   }
 
   @override
@@ -403,6 +424,7 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
                     ),
                   )
                 : ListView.builder(
+                    controller: _scrollController,
                     padding: const EdgeInsets.symmetric(horizontal: 20),
                     itemCount: _messages.length + (_isProcessing ? 1 : 0),
                     itemBuilder: (context, index) {

--- a/frontend/lib/screens/conversation_screen_simple.dart
+++ b/frontend/lib/screens/conversation_screen_simple.dart
@@ -84,10 +84,8 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
       await _webSocketService.connect(_conversationId);
       print('✅ WebSocket 연결 완료');
       
-      // 잠시 대기 후 초기 메시지 전송
-      await Future.delayed(const Duration(milliseconds: 1000));
-      print('💬 초기 메시지 전송');
-      _sendMessage('안녕하세요! 이 사진에 대해 이야기해보세요.');
+      // 자동 메시지 전송 제거 - 사용자가 직접 대화를 시작하도록 함
+      print('✅ WebSocket 연결 완료, 사용자 입력 대기 중');
       
     } catch (e) {
       print('❌ 대화 초기화 실패: $e');
@@ -377,38 +375,65 @@ class _PhotoConversationScreenState extends State<PhotoConversationScreen> {
           ),
           // 메시지 목록
           Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.symmetric(horizontal: 20),
-              itemCount: _messages.length + (_isProcessing ? 1 : 0),
-              itemBuilder: (context, index) {
-                if (index == _messages.length && _isProcessing) {
-                  // 처리 중 메시지 표시
-                  return Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    child: AssistantBubble(
-                      text: _processingMessage,
-                      isActive: true,
-                    ),
-                  );
-                }
-                
-                final message = _messages[index];
-                final isAi = message['type'] == 'ai';
-                
-                return Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: isAi
-                      ? AssistantBubble(
-                          text: message['text'],
-                          isActive: false,
-                        )
-                      : UserSpeechBubble(
-                          text: message['text'],
-                          isActive: false,
+            child: _messages.isEmpty && !_isProcessing
+                ? Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          Icons.chat_bubble_outline,
+                          size: 64,
+                          color: Colors.grey[400],
                         ),
-                );
-              },
-            ),
+                        const SizedBox(height: 24),
+                        const Text(
+                          '메시지를 입력하여\n대화를 시작해보세요.',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: 18,
+                            color: Color(0xFF666666),
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w600,
+                            height: 1.5,
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.symmetric(horizontal: 20),
+                    itemCount: _messages.length + (_isProcessing ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      if (index == _messages.length && _isProcessing) {
+                        // 처리 중 메시지 표시
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: AssistantBubble(
+                            text: _processingMessage,
+                            isActive: true,
+                          ),
+                        );
+                      }
+                      
+                      final message = _messages[index];
+                      final isAi = message['type'] == 'ai';
+                      
+                      return Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        child: isAi
+                            ? AssistantBubble(
+                                text: message['text'],
+                                isActive: false,
+                              )
+                            : UserSpeechBubble(
+                                text: message['text'],
+                                isActive: false,
+                              ),
+                      );
+                    },
+                  ),
           ),
           // 메시지 입력 영역
           Container(

--- a/frontend/lib/widgets/user_speech_bubble.dart
+++ b/frontend/lib/widgets/user_speech_bubble.dart
@@ -16,14 +16,8 @@ class UserSpeechBubble extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.end,
         children: [
-          Image.asset(
-            'assets/icons/Mic.png',
-            color: isActive ? Color(0xFFD95753) : null,
-            // Color(0xFF555555)
-            colorBlendMode: BlendMode.srcIn,
-          ),
-          const SizedBox(width: 12),
           Flexible(
             child: Container(
               padding: const EdgeInsets.all(12),
@@ -41,6 +35,13 @@ class UserSpeechBubble extends StatelessWidget {
                 ),
               ),
             ),
+          ),
+          const SizedBox(width: 12),
+          Image.asset(
+            'assets/icons/Mic.png',
+            color: isActive ? Color(0xFFD95753) : null,
+            // Color(0xFF555555)
+            colorBlendMode: BlendMode.srcIn,
           ),
         ],
       ),

--- a/supabase/migrations/20250831135056_rename_conversation_columns.sql
+++ b/supabase/migrations/20250831135056_rename_conversation_columns.sql
@@ -1,0 +1,23 @@
+-- Rename and reorder conversation table columns
+-- question_text -> ai_output
+-- user_response_text -> user_input
+-- Reorder columns: conversation_order, user_input, ai_output
+
+alter table "public"."conversations" rename column "question_text" to "ai_output";
+alter table "public"."conversations" rename column "user_response_text" to "user_input";
+
+-- Reorder columns by creating new columns in desired order and copying data
+alter table "public"."conversations" add column "user_input_new" text;
+alter table "public"."conversations" add column "ai_output_new" text;
+
+-- Copy data to new columns
+update "public"."conversations" set "user_input_new" = "user_input";
+update "public"."conversations" set "ai_output_new" = "ai_output";
+
+-- Drop old columns
+alter table "public"."conversations" drop column "user_input";
+alter table "public"."conversations" drop column "ai_output";
+
+-- Rename new columns to final names
+alter table "public"."conversations" rename column "user_input_new" to "user_input";
+alter table "public"."conversations" rename column "ai_output_new" to "ai_output";


### PR DESCRIPTION
### 변경사항
- conversations 테이블 컬럼명 변경
  - `question_text` → `ai_output`
  - `user_response_text` → `user_input`
- 대화 시작 시 흐름 수정
  - 기존에는 `대화하기` 버튼 클릭 시 첫 user_input이 자동으로 '안녕하세요! 이 사진에 대해 이야기해보세요.'가 들어감
  - 대화 시작 시 자동으로 user_input이 들어가지 않도록 수정
- 대화 화면에서 현재 대화 턴이 보이도록 자동 스크롤 적용
- 대화 화면에서 `user_input`은 오른쪽, `ai_output`은 왼쪽으로 수정